### PR TITLE
Migrate to CancellationTask where appropriate

### DIFF
--- a/Technetium.Console/ConsoleUtil.fs
+++ b/Technetium.Console/ConsoleUtil.fs
@@ -1,0 +1,17 @@
+﻿module Technetium.Console.ConsoleUtil
+
+open System
+open System.Threading
+open System.Threading.Tasks
+
+open IcedTasks.CancellableTasks
+
+let WithConsoleCancellationToken(cancellableTask: CancellableTask<'a>): Task<'a> = task {
+    use cts = new CancellationTokenSource()
+    use _ = Console.CancelKeyPress.Subscribe(fun args ->
+        printfn "Cancellation requested."
+        args.Cancel <- true // tell the runtime that we'll handle the cancellation
+        cts.Cancel()
+    )
+    return! cancellableTask cts.Token
+}

--- a/Technetium.Console/Technetium.Console.fsproj
+++ b/Technetium.Console/Technetium.Console.fsproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <Compile Include="Configuration.fs" />
+        <Compile Include="ConsoleUtil.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/Technetium.Google/Technetium.Google.fsproj
+++ b/Technetium.Google/Technetium.Google.fsproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
       <PackageReference Include="Google.Apis.Auth" Version="1.64.0" />
+      <PackageReference Include="IcedTasks" Version="0.10.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Technetium.Web/Program.cs
+++ b/Technetium.Web/Program.cs
@@ -18,6 +18,6 @@ public class Program
         application.MapGet("/", () => Results.LocalRedirect("/index.html"));
         application.UseStaticFiles();
 
-        application.Run();
+        await application.RunAsync();
     }
 }


### PR DESCRIPTION
Closes #14.

From now on, we'll write all new code in a properly cancellable manner. On the F # side, we'll use `cancellableTask` and IcedTasks everywhere, and on the C # side, just pass around the cancellation token when possible.